### PR TITLE
Ассоциации на Theme и Asset. Указан правильный префикс для ассетов.

### DIFF
--- a/lib/insales_api/asset.rb
+++ b/lib/insales_api/asset.rb
@@ -1,3 +1,5 @@
 module InsalesApi
-  class Asset < Base; end
+  class Asset < Base
+    self.prefix = "/admin/themes/:theme_id/"
+  end
 end

--- a/lib/insales_api/theme.rb
+++ b/lib/insales_api/theme.rb
@@ -1,3 +1,5 @@
 module InsalesApi
-  class Theme < Base; end
+  class Theme < Base
+    has_many :assets, class_name: 'InsalesApi::Asset'
+  end
 end


### PR DESCRIPTION
Указаны ассоциации на Theme и Asset, чтобы можно было получить список ассетов темы:

``` ruby
theme = InsalesApi::Theme.first
assets = theme.assets
```

Префикс для ассетов указан из-за бага в Active Resource, когда некорректно генерируется REST-овый урл для вложенных ресурсов:

https://github.com/rails/activeresource/issues/16
