### PR TITLE
Возможность получения ассетов

### DIFF
--- a/lib/insales_api/asset.rb
+++ b/lib/insales_api/asset.rb
@@ -1,3 +1,5 @@
 module InsalesApi
-  class Asset < Base; end
+  class Asset < Base
+    self.prefix = "#{prefix}themes/:theme_id/"
+  end
 end

--- a/lib/insales_api/theme.rb
+++ b/lib/insales_api/theme.rb
@@ -1,3 +1,9 @@
 module InsalesApi
-  class Theme < Base; end
+  class Theme < Base
+
+    def assets
+      InsalesApi::Asset.all(params: {theme_id: id})
+    end
+
+  end
 end


### PR DESCRIPTION
Указан префикс для ассетов, чтобы можно было их получить:

``` ruby
assets = InsalesApi::Asset.all(params: {theme_id: 11111})
```

В Theme добавлен метод, позволяющий получить список ассетов. `has_many` не используется.

``` ruby
theme = InsalesApi::Theme.first
assets = theme.assets
```
