### PR TITLE
Поправил insales.rb, для совместимости с ActiveSupport 4.1.0

### DIFF
--- a/lib/insales_api.rb
+++ b/lib/insales_api.rb
@@ -1,4 +1,5 @@
 require 'digest/md5'
+require 'active_support'
 require 'active_support/core_ext'
 require 'active_resource'
 # backport from 4.0


### PR DESCRIPTION
При использовании ActiveSupport 4.1.0 в момент подключения core_ext возникает исключение _module:NumberHelper': uninitialized constant ActiveSupport::Autoload (NameError)_. Устраняется добавлением двух require-ов.
