### PR TITLE
wait_retry - Вызов блока с ожиданием, если лимит Insales достигнут

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,26 @@ order = InsaleApi::Order.find 123
 # singleton resources
 account = InsaleApi::Account.find
 ```
+
+### Handling Insales API request limit
+
+There is a 500 requests per 5 minutes limit for Insales API. To handle this limitation gracefully, use `InsalesApi.wait_retry` method:
+```ruby
+# prepare a handler for request limit case
+notify_user = Proc.new do |wait_for, attempt, max_attempts, ex|
+  puts "API limit reached. Waiting for #{wait_for} seconds. Attempt #{attempt}/#{max_attempts}"
+end
+
+# perform 10 attempts to get products
+InsalesApi.wait_retry(10, notify_user) do |x|
+  puts "Attempt ##{x}."
+  products = InsalesApi::Products.all
+end
+```
+
+If you don't need to cap the attempts number or you don't want to do any special processing, simply drop the arguments:
+```ruby
+InsalesApi.wait_retry do
+  products = InsalesApi::Products.all # will try to get products until the limit resets
+end
+```

--- a/lib/insales_api.rb
+++ b/lib/insales_api.rb
@@ -44,6 +44,48 @@ module InsalesApi
     autoload :Variant
     autoload :Webhook
   end
+
+  class << self
+    # Calls the supplied block. If the block raises <tt>ActiveResource::ServerError</tt> with 503
+    # code which means Insales API request limit is reached, it will wait for the amount of seconds
+    # specified in 'Retry-After' response header. The called block will receive a parameter with
+    # current attempt number.
+    #
+    # ==== Params:
+    #
+    #   +max_attempts+:: maximum number of attempts. Defaults to +nil+ (unlimited).
+    #   +callback+:: +Proc+ or lambda to execute before waiting. Will receive four arguments: number
+    #                of seconds we are going to wait, number of failed attempts, maximum number of
+    #                attempts and the caught <tt>ActiveResource::ServerError</tt>. Defaults to +nil+
+    #                (no callback).
+    #
+    # ==== Example
+    #
+    #   notify_user = Proc.new do |wait_for, attempt, max_attempts, ex|
+    #     puts "API limit reached. Waiting for #{wait_for} seconds. Attempt #{attempt}/#{max_attempts}"
+    #   end
+    #
+    #   InsalesApi.wait_retry(10, notify_user) do |x|
+    #     puts "Attempt ##{x}."
+    #     products = InsalesApi::Products.all
+    #   end
+    def wait_retry(max_attempts = nil, callback = nil, &block)
+      attempts = 0
+
+      begin
+        attempts += 1
+        yield attempts
+      rescue ActiveResource::ServerError => ex
+        raise ex if '503' != ex.response.code.to_s
+        raise ex if max_attempts && attempts >= max_attempts
+        retry_after = (ex.response['Retry-After'] || 150).to_i
+        callback.call(retry_after, attempts, max_attempts, ex) if callback
+        sleep(retry_after)
+        retry
+      end
+    end
+  end
+
 end
 
 require 'insales_api/helpers/init_api'

--- a/spec/lib/insales_api_spec.rb
+++ b/spec/lib/insales_api_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+describe InsalesApi do
+
+  describe '.wait_retry' do
+
+    response_stub = Struct.new(:code, :retry_after) do
+      def [](key)
+        {'Retry-After' => retry_after}[key]
+      end
+    end
+
+    it 'should not run without block' do
+      expect do
+        described_class.wait_retry(20, nil)
+      end.to raise_error
+    end
+
+    it 'should handle succesfull request' do
+      counter = 0
+      described_class.wait_retry do
+        counter += 1
+      end
+
+      expect(counter).to eq(1)
+    end
+
+    it 'should make specified amount of attempts' do
+      counter = 0
+      described_class.wait_retry(3) do
+        counter += 1
+
+        if counter < 3
+          raise ActiveResource::ServerError.new(response_stub.new("503", "0"))
+        end
+      end
+
+      expect(counter).to eq(3)
+    end
+
+    it 'should use callback proc' do
+      callback = Proc.new{}
+      counter = 0
+      callback.should_receive(:call).with(0, 1, 3, instance_of(ActiveResource::ServerError))
+      callback.should_receive(:call).with(0, 2, 3, instance_of(ActiveResource::ServerError))
+
+      described_class.wait_retry(3, callback) do
+        counter += 1
+
+        if counter < 3
+          raise ActiveResource::ServerError.new(response_stub.new("503", "0"))
+        end
+      end
+    end
+
+    it 'should pass attempt number to block' do
+      last_attempt_no = 0
+      described_class.wait_retry(3) do |x|
+        last_attempt_no = x
+
+        if last_attempt_no < 3
+          raise ActiveResource::ServerError.new(response_stub.new("503", "0"))
+        end
+      end
+
+      expect(last_attempt_no).to eq(3)
+    end
+
+    it 'should raise if no attempts left' do
+      expect do
+        described_class.wait_retry(3) do |x|
+          raise ActiveResource::ServerError.new(response_stub.new("503", "0"))
+        end
+      end.to raise_error(ActiveResource::ServerError)
+    end
+
+    it 'should raise on user errors' do
+      attempts = 0
+      expect do
+        described_class.wait_retry(3) do |x|
+          attempts = x
+          raise 'Some other error'
+        end
+      end.to raise_error(StandardError)
+      expect(attempts).to eq(1)
+    end
+
+    it 'should raise on other server errors' do
+      attempts = 0
+      expect do
+        described_class.wait_retry(3) do |x|
+          attempts = x
+          raise ActiveResource::ServerError.new(response_stub.new("502", "0"))
+        end
+      end.to raise_error(ActiveResource::ServerError)
+      expect(attempts).to eq(1)
+    end
+
+    it 'should run until success' do |x|
+      success = false
+      described_class.wait_retry do |x|
+        raise ActiveResource::ServerError.new(response_stub.new("503", "0")) if x < 10
+        success = true
+      end
+
+      expect(success).to be_true
+    end
+  end
+
+end


### PR DESCRIPTION
Предлагаю ввести метод `InsalesApi::wait_retry`, который позволяет выполнять блок кода с обращением к API. При достижении лимита запросов метод будет ожидать указанное количество времени, после чего повторит попытку. Такой подход в наших приложениях себя очень хорошо зарекомендовал. 

Все детально покрыто тестами.

Пример.

``` ruby
notify_user = Proc.new do |wait_for, attempt, max_attempts, ex|
  puts "API limit reached. Waiting for #{wait_for} seconds. Attempt #{attempt}/#{max_attempts}"
end

InsalesApi::wait_retry(10, notify_user) do |x|
  puts "Attempt ##{x}."
  products = InsalesApi::Products.all
end
```
