### PR TITLE
Fiexed get count

### DIFF
--- a/lib/insales_api/resource/countable.rb
+++ b/lib/insales_api/resource/countable.rb
@@ -2,7 +2,7 @@ module InsalesApi
   module Resource
     module Countable
       def count(options = {})
-        get(:count, options).to_i
+        get(:count, options)['count'].to_i
       end
     end
   end


### PR DESCRIPTION
При вызове `InsalesApi::Product.count` кидает:
```
NoMethodError (undefined method `to_i' for {"count"=>1234}:Hash
Did you mean?  to_s
               to_a
               to_h):
```
Это должно пофиксить